### PR TITLE
Bootstrap for 12.04 and 14.04

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 #
-# Bootstrap Puppet on Ubuntu 12.04 LTS
+# Bootstrap Puppet on Ubuntu 12.04 or 14.04 LTS.
 #
 set -e
-shopt -s expand_aliases
 
 # Load up the release information
 . /etc/lsb-release
@@ -12,31 +11,61 @@ REPO_DEB_URL="https://apt.puppetlabs.com/puppetlabs-release-${DISTRIB_CODENAME}.
 
 PRIVATE_REPO_URL="git@github.com:leukeleu/puppet-server-base.git"
 
-#------------------------------------------------------------------------------
+#--------------------------------------------------------------------
+# NO TUNABLES BELOW THIS POINT
+#--------------------------------------------------------------------
 
-echo "Preparing system..."
-sudo rm -rf /var/lib/apt/lists/*
+# Do the initial apt-get update
+echo "Initial apt-get update..."
 sudo apt-get update >/dev/null
-sudo apt-get upgrade -y >/dev/null
-sudo apt-get install -y build-essential >/dev/null
 
-# Install latest Puppet from PuppetLabs repo
+# Install wget if we have to (some older Ubuntu versions)
+echo "Installing wget..."
+sudo apt-get --yes install wget >/dev/null
+
+# Install the PuppetLabs repo
 echo "Configuring PuppetLabs repo..."
 repo_deb_path=$(mktemp)
-wget --output-document=${repo_deb_path} ${REPO_DEB_URL} 2>/dev/null
-sudo dpkg -i ${repo_deb_path} >/dev/null
+wget --output-document="${repo_deb_path}" "${REPO_DEB_URL}" 2>/dev/null
+sudo dpkg -i "${repo_deb_path}" >/dev/null
 sudo apt-get update >/dev/null
 
+# Install Puppet
 echo "Installing Puppet..."
-sudo apt-get install -y puppet >/dev/null
+DEBIAN_FRONTEND=noninteractive sudo apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install puppet >/dev/null
+
+echo "Puppet installed!"
+
+# Install RubyGems for the provider
+echo "Installing RubyGems..."
+if [ "$DISTRIB_CODENAME" == "precise" ]; then
+  sudo apt-get --yes install rubygems >/dev/null
+fi
+sudo gem install --no-ri --no-rdoc rubygems-update
+sudo update_rubygems >/dev/null
+
+#--------------------------------------------------------------------
+# Leukeleu custom bits
+#--------------------------------------------------------------------
+
+echo "Installing build-essentials..."
+sudo apt-get install -y build-essential >/dev/null
 
 echo "Installing git..."
 sudo apt-get install -y git >/dev/null
 
-# Install librarian-puppet that is compatible with Ruby 1.8.7
-echo "Installing librarian..."
-sudo apt-get install -y rubygems >/dev/null
-sudo gem install librarian-puppet -v 1.5.0 --no-ri --no-rdoc >/dev/null
+echo "Installing system updates..."
+sudo apt-get upgrade -y >/dev/null
+
+echo "Installing librarian-puppet..."
+if [ "$DISTRIB_CODENAME" == "precise" ]; then
+  # Install librarian-puppet that is compatible with Ruby 1.8.7
+  sudo gem install librarian-puppet -v 1.5.0 --no-ri --no-rdoc >/dev/null
+else
+  # Install the latest librarian-puppet
+  sudo apt-get install -y ruby-dev >/dev/null
+  sudo gem install librarian-puppet --no-ri --no-rdoc >/dev/null
+fi
 
 # Ask for the location of the private Puppet repository
 read -e -p "Enter the location of the private Puppet repository: " -i "${PRIVATE_REPO_URL}" PRIVATE_REPO_URL </dev/tty
@@ -62,8 +91,8 @@ if [ ! -d ~/etc/puppet/.git ]; then
 fi
 
 # Add aliases
-grep -q puppet-update ~/.bash_aliases 2> /dev/null || echo -e $'alias puppet-update=\'bash -c \"if [ -d ~/etc/puppet-manifests ]; then cd ~/etc/puppet-manifests && (git pull -q || true); fi && cd ~/etc/puppet/ && (git pull -q || true) && librarian-puppet install --quiet && echo \\\"Done!\\\"\"\'' >> ~/.bash_aliases
-grep -q puppet-apply ~/.bash_aliases 2> /dev/null || echo "alias puppet-apply='sudo bash -c \"FACTER_user=\$USER puppet apply --confdir=~/etc/puppet --modulepath=~/etc/puppet/modules/ops:~/etc/puppet/modules/dev:~/etc/puppet/modules/lib --manifest=~/etc/puppet/manifests ~/etc/puppet/manifests\"'" >> ~/.bash_aliases
+echo -e $'alias puppet-update=\'bash -c \"if [ -d ~/etc/puppet-manifests ]; then cd ~/etc/puppet-manifests && (git pull -q || true); fi && cd ~/etc/puppet/ && (git pull -q || true) && librarian-puppet install --quiet && echo \\\"Done!\\\"\"\'' > ~/.bash_aliases
+echo "alias puppet-apply='sudo bash -c \"FACTER_user=\$USER puppet apply --confdir=~/etc/puppet --modulepath=~/etc/puppet/modules/ops:~/etc/puppet/modules/dev:~/etc/puppet/modules/lib --manifest=~/etc/puppet/manifests ~/etc/puppet/manifests\"'" >> ~/.bash_aliases
 source ~/.bash_aliases
 
 # Bootstrap Puppet


### PR DESCRIPTION
Updated with handpicked changes from https://github.com/hashicorp/puppet-bootstrap and ubuntu14.04 branch. Should work on 12.04 and 14.04.

Will also always overwrite ~/.bash_aliases to prevent stale aliases.